### PR TITLE
Allows Centos to compile without error

### DIFF
--- a/lite/post.cpp
+++ b/lite/post.cpp
@@ -5466,7 +5466,11 @@ if (!Var::val(_T("Base"), nlppp->parse_, /*DU*/ base))
 	return true;	// Input doc's problem: relative urls with no base.
 
 _TCHAR burl[MAXSTR];
-_tcscpy(burl, base);		// For mangling.
+if (base != NULL) {
+	_tcscpy(burl, base);		// For mangling.
+} else {
+	burl[0] = '\0';
+}
 
 // Parse the base URL.  Note: URL buffer gets mangled.
 _TCHAR *bservice, *bserver, *bdirs, *bfile, *bport;


### PR DESCRIPTION
Null check to allow centos to compile. I had this change for a while but somehow it did not make it into the master nlp-engine repository.